### PR TITLE
Updated dependency to prevent error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.12.0"
+    "yeoman-generator": ">=0.13.0"
   },
   "peerDependencies": {
     "yo": ">=1.0.0-rc.1.4"


### PR DESCRIPTION
I was having trouble with using the generator, so I moved the yeoman-generator dependency to 0.13.0 or higher in the package.json.

Noted here: https://github.com/yeoman/generator-webapp/issues/138
